### PR TITLE
Add conversion script from greenbay to redalert

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+click==6.7
+PyYAML==3.12
+pyaml

--- a/scripts/convert_greenbay_yaml.py
+++ b/scripts/convert_greenbay_yaml.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""This source codifies our deprecations and argument modifications to the
+Greenbay.yaml format. It takes a single argument: the path to the greenbay.yaml and will create a redalert.yaml from it."""
+
+import sys
+from collections import OrderedDict
+
+import pyaml
+import yaml
+
+
+# Make it so yaml multi line strings use the | syntax that we prefer
+def str_presenter(dumper, data):
+    data = data.rstrip()
+    if len(data.splitlines()) > 1:  # check for multiline string
+        return dumper.represent_scalar(
+            'tag:yaml.org,2002:str', data, style='|')
+    if data.startswith('{') or data.endswith('}'):
+        return dumper.represent_scalar(
+            'tag:yaml.org,2002:str', data, style="'")
+    return dumper.represent_scalar('tag:yaml.org,2002:str', data, style='')
+
+
+pyaml.add_representer(str, str_presenter)
+
+
+def represent_ordereddict(dumper, data):
+    value = []
+
+    if 'name' in data and 'suites' in data:
+        for key in ['name', 'suites', 'type', 'args']:
+            value.append((dumper.represent_data(key),
+                          dumper.represent_data(data[key])))
+    else:
+        for item_key, item_value in data.items():
+            node_key = dumper.represent_data(item_key)
+            node_value = dumper.represent_data(item_value)
+            value.append((node_key, node_value))
+
+    return yaml.nodes.MappingNode(u'tag:yaml.org,2002:map', value)
+
+
+pyaml.add_representer(OrderedDict, represent_ordereddict)
+pyaml.add_representer(dict, represent_ordereddict)
+
+
+def convert_shell_operation(test):
+    """shell-operation superseded by run-bash-script"""
+    cmd = test['args'].pop('command')
+    test['args']['source'] = cmd.strip()
+    test['type'] = 'run-bash-script'
+    return test
+
+
+def convert_run_program_system_python(test):
+    """run-program-system-python* superseded by run-python-script"""
+    if 'windows' in test['name'] and test['type'].endswith('python2'):
+        test['args']['interpreter'] = 'C:\\Python27\\python.exe'
+    elif 'windows' in test['name']:
+        test['args']['interpreter'] = 'C:\\Python36\\python.exe'
+    elif test['type'].endswith('python2'):
+        test['args']['interpreter'] = 'python2'
+    test['type'] = 'run-python-source'
+    return test
+
+
+def convert_command_group_all(test):
+    """command-group-all superseded by run-bash-script and run-powershell-source"""
+    cmds = [x['command'] for x in test['args'].pop('commands')]
+    test['args']['source'] = '\n'.join(cmds)
+    if 'windows' in test['name']:
+        test['type'] = 'run-powershell-source'
+    return test
+
+
+def convert_compile_gcc(test):
+    """compile-*gcc-auto superseded by compile-gcc"""
+    if 'and-run' in test['type']:
+        test['args']['run'] = True
+    test['type'] = 'compile-gcc'
+    return test
+
+
+TRANSLATION_TABLE = {
+    'shell-operation': convert_shell_operation,
+    'run-program-system-python': convert_run_program_system_python,
+    'run-program-system-python2': convert_run_program_system_python,
+    'command-group-all': convert_command_group_all,
+    'compile-and-run-gcc-auto': convert_compile_gcc,
+    'compile-gcc-auto': convert_compile_gcc
+}
+
+
+def convert(test):
+    """Convert a test if necessary."""
+    if test['type'] in TRANSLATION_TABLE:
+        print('Found superseded test:', test['type'])
+        translation = TRANSLATION_TABLE[test['type']]
+        print(translation.__doc__)
+        return translation(test)
+    return test
+
+
+def main():
+    greenbay_yaml_path = sys.argv[1]
+    with open(greenbay_yaml_path) as gyml:
+        greenbay_yaml = yaml.load(gyml)
+
+    redalert_yaml = {'tests': []}
+    tests = greenbay_yaml['tests']
+    for test in tests:
+        redalert_yaml['tests'].append(convert(test))
+
+    with open('redalert.yaml', 'w') as ryml:
+        ryml.write(pyaml.dump(redalert_yaml))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/convert_greenbay_yaml.py
+++ b/scripts/convert_greenbay_yaml.py
@@ -60,16 +60,16 @@ def convert_run_program_system_python(test):
         test['args']['interpreter'] = 'C:\\Python36\\python.exe'
     elif test['type'].endswith('python2'):
         test['args']['interpreter'] = 'python2'
-    test['type'] = 'run-python-source'
+    test['type'] = 'run-python-script'
     return test
 
 
 def convert_command_group_all(test):
-    """command-group-all superseded by run-bash-script and run-powershell-source"""
+    """command-group-all superseded by run-bash-script and run-powershell-script"""
     cmds = [x['command'] for x in test['args'].pop('commands')]
     test['args']['source'] = '\n'.join(cmds)
     if 'windows' in test['name']:
-        test['type'] = 'run-powershell-source'
+        test['type'] = 'run-powershell-script'
     return test
 
 

--- a/scripts/convert_greenbay_yaml.py
+++ b/scripts/convert_greenbay_yaml.py
@@ -112,7 +112,7 @@ def main():
         redalert_yaml['tests'].append(convert(test))
 
     with open('redalert.yaml', 'w') as ryml:
-        ryml.write(pyaml.dump(redalert_yaml))
+        ryml.write(pyaml.dump(redalert_yaml, vspacing=[2, 1]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
A diff from our greenbay.yaml to the redalert.yaml this generated:

```
6c6
<     type: shell-operation
---
>     type: run-bash-script
8,9c8
<       command: "ghc --version"
< 
---
>       source: ghc --version
14c13
<     type: shell-operation
---
>     type: run-bash-script
16,17c15
<       command: "cabal --version"
< 
---
>       source: cabal --version
22c20
<     type: shell-operation
---
>     type: run-bash-script
24,25c22
<       command: "hlint --version"
< 
---
>       source: hlint --version
30c27
<     type: shell-operation
---
>     type: run-bash-script
32,33c29
<       command: "happy --version"
< 
---
>       source: happy --version
38c34
<     type: shell-operation
---
>     type: run-bash-script
40,41c36
<       command: "/opt/terraform/terraform --version"
< 
---
>       source: /opt/terraform/terraform --version
48d42
< 
56d49
< 
74c67
<     type: shell-operation
---
>     type: run-bash-script
76,77c69
<       command: "automake --version"
< 
---
>       source: automake --version
95c87
<     type: shell-operation
---
>     type: run-bash-script
97,98c89
<       command: "autoreconf --version"
< 
---
>       source: autoreconf --version
119c110
<     type: shell-operation
---
>     type: run-bash-script
121,122c112
<       command: "bc --version"
< 
---
>       source: bc --version
139c129
<     type: shell-operation
---
>     type: run-bash-script
141,142c131
<       command: "bison --version"
< 
---
>       source: bison --version
146c135
<     type: shell-operation
---
>     type: run-bash-script
148,149c137
<       command: "rpm -q gpg-pubkey | grep gpg-pubkey-c105b9de-4e0fd3a3"
< 
---
>       source: rpm -q gpg-pubkey | grep gpg-pubkey-c105b9de-4e0fd3a3
166c154
<     type: shell-operation
---
>     type: run-bash-script
168,169c156
<       command: "runtest --version"
< 
---
>       source: runtest --version
185c172
<     type: shell-operation
---
>     type: run-bash-script
187,188c174
<       command: "grep fs-727b3b3b.efs.us-east-1.amazonaws.com /etc/fstab"
< 
---
>       source: grep fs-727b3b3b.efs.us-east-1.amazonaws.com /etc/fstab
205c191
<     type: shell-operation
---
>     type: run-bash-script
207,208c193
<       command: "flex --version"
< 
---
>       source: flex --version
225c210
<     type: shell-operation
---
>     type: run-bash-script
227,228c212
<       command: "test $(df /opt | awk 'NR>1 {print $4}' | grep -Eo '[0-9]+') -gt 2097152"
< 
---
>       source: test $(df /opt | awk 'NR>1 {print $4}' | grep -Eo '[0-9]+') -gt 2097152
245c229
<     type: shell-operation
---
>     type: run-bash-script
247,248c231
<       command: "test $(df / | awk 'NR>1 {print $4}' | grep -Eo '[0-9]+') -gt 2097152"
< 
---
>       source: test $(df / | awk 'NR>1 {print $4}' | grep -Eo '[0-9]+') -gt 2097152
254c237
<     type: shell-operation
---
>     type: run-bash-script
256,257c239,240
<       command: "test $(df /cygdrive/c/ | awk 'NR>1 {print $4}' | grep -Eo '[0-9]+') -gt 2097152"
< 
---
>       source: test $(df /cygdrive/c/ | awk 'NR>1 {print $4}' | grep -Eo '[0-9]+')
>         -gt 2097152
278c261
<       source: |
---
>       source: |-
291d273
< 
311c293
<       source: |
---
>       source: |-
324d305
< 
328c309
<     type: shell-operation
---
>     type: run-bash-script
330,331c311
<       command: "gconftool-2 --version"
< 
---
>       source: gconftool-2 --version
335c315
<     type: shell-operation
---
>     type: run-bash-script
337,338c317
<       command: "git version"
< 
---
>       source: git version
344,347c323,324
<       source: |
<         git version
<       output: "git version 2.13.2"
< 
---
>       source: git version
>       output: git version 2.13.2
370c347
<     type: run-program-system-python
---
>     type: run-python-source
372c349
<       source: |
---
>       source: |-
380,381c357
<       output: "1.7"
< 
---
>       output: '1.7'
395c371
<     type: shell-operation
---
>     type: run-bash-script
397,398c373
<       command: "GOROOT=/opt/golang/go1.10 /opt/golang/go1.10/bin/go version"
< 
---
>       source: GOROOT=/opt/golang/go1.10 /opt/golang/go1.10/bin/go version
406c381
<     type: shell-operation
---
>     type: run-bash-script
408,409c383
<       command: "GOROOT='C:\\golang\\go1.10.1' /cygdrive/c/golang/go1.10.1/bin/go version"
< 
---
>       source: GOROOT='C:\golang\go1.10.1' /cygdrive/c/golang/go1.10.1/bin/go version
413c387
<     type: run-program-system-python
---
>     type: run-python-source
415c389
<       source: |
---
>       source: |-
423,424c397
<       output: "1.10"
< 
---
>       output: '1.10'
442c415
<     type: run-program-system-python
---
>     type: run-python-source
444c417
<       source: |
---
>       source: |-
452,453c425
<       output: "1.7"
< 
---
>       output: '1.7'
462c434
<     type: run-program-system-python
---
>     type: run-python-source
464c436
<       source: |
---
>       source: |-
472,473c444,445
<       output: "1.7"
< 
---
>       output: '1.7'
>       interpreter: C:\Python36\python.exe
491c463
<     type: run-program-system-python
---
>     type: run-python-source
493c465
<       source: |
---
>       source: |-
501,502c473
<       output: "1.8"
< 
---
>       output: '1.8'
511c482
<     type: run-program-system-python
---
>     type: run-python-source
513c484
<       source: |
---
>       source: |-
521,522c492,493
<       output: "1.8"
< 
---
>       output: '1.8'
>       interpreter: C:\Python36\python.exe
543,544c514
<       name: "/opt/go"
< 
---
>       name: /opt/go
554,555c524
<       name: "c:\\go\\bin\\go.exe"
< 
---
>       name: c:\go\bin\go.exe
564c533
<     type: shell-operation
---
>     type: run-bash-script
566,567c535
<       command: "dot -V"
< 
---
>       source: dot -V
571c539
<     type: shell-operation
---
>     type: run-bash-script
573,574c541
<       command: "/cygdrive/c/Program\\ Files\\ \\(x86\\)/Graphviz2.38/bin/dot.exe -V"
< 
---
>       source: /cygdrive/c/Program\ Files\ \(x86\)/Graphviz2.38/bin/dot.exe -V
578c545
<     type: shell-operation
---
>     type: run-bash-script
580,581c547
<       command: "gzip --version"
< 
---
>       source: gzip --version
598c564
<       source: |
---
>       source: |-
606d571
< 
630,631c595
<       name: "/etc/mongodb-build-system-id"
< 
---
>       name: /etc/mongodb-build-system-id
642,643c606
<       name: "c:\\mongodb-build-system-id"
< 
---
>       name: c:\mongodb-build-system-id
649,650c612
<       name: "/usr/bin/install-ec2-credential"
< 
---
>       name: /usr/bin/install-ec2-credential
658c620
<     type: shell-operation
---
>     type: run-bash-script
660,661c622,623
<       command: "if REG QUERY \"HKEY_LOCAL_MACHINE\\SYSTEM\\ControlSet001\\Control\\Lsa\\Kerberos\\Domains\\LDAPTEST.10GEN.CC\"; then exit 0;else exit 1;fi"
< 
---
>       source: if REG QUERY "HKEY_LOCAL_MACHINE\SYSTEM\ControlSet001\Control\Lsa\Kerberos\Domains\LDAPTEST.10GEN.CC";
>         then exit 0;else exit 1;fi
669c631
<     type: shell-operation
---
>     type: run-bash-script
671,672c633,634
<       command: "if REG QUERY \"HKEY_LOCAL_MACHINE\\SYSTEM\\ControlSet001\\Control\\Lsa\\Kerberos\\Domains\\LDAPTEST2.10GEN.CC\"; then exit 0;else exit 1;fi"
< 
---
>       source: if REG QUERY "HKEY_LOCAL_MACHINE\SYSTEM\ControlSet001\Control\Lsa\Kerberos\Domains\LDAPTEST2.10GEN.CC";
>         then exit 0;else exit 1;fi
689c651
<     type: shell-operation
---
>     type: run-bash-script
691,692c653
<       command: "libtoolize --version"
< 
---
>       source: libtoolize --version
698,699c659
<       name: "/usr/lib/libXss.so.1.0.0"
< 
---
>       name: /usr/lib/libXss.so.1.0.0
702,712c662,671
<     - debian71
<     - debian81
<     - debian9
<     - rhel62
<     - rhel70
<     - ubuntu1204
<     - ubuntu1404
<     - ubuntu1410
<     - ubuntu1604
<       - ubuntu1804
<     type: shell-operation
---
>       - debian71
>       - debian81
>       - debian9
>       - rhel62
>       - rhel70
>       - ubuntu1204
>       - ubuntu1404
>       - ubuntu1410
>       - ubuntu1604 - ubuntu1804
>     type: run-bash-script
714,715c673
<       command: "lsb_release"
< 
---
>       source: lsb_release
733c691
<     type: shell-operation
---
>     type: run-bash-script
735,736c693
<       command: "make --version"
< 
---
>       source: make --version
742,743c699
<       name: "/home/mci/.ssh/authorized_keys"
< 
---
>       name: /home/mci/.ssh/authorized_keys
749,752c705,706
<       source: |
<         cat /home/mci/.ssh/authorized_keys | grep 'mci$' | awk '{print $3}'
<       output: "mci"
< 
---
>       source: cat /home/mci/.ssh/authorized_keys | grep 'mci$' | awk '{print $3}'
>       output: mci
777,780c731,733
<       module: "psutil"
<       statement: "psutil.__version__"
<       version: "5.2.2"
< 
---
>       module: psutil
>       statement: psutil.__version__
>       version: 5.2.2
786,789c739,741
<       module: "psutil"
<       statement: "psutil.__version__"
<       version: "5.2.1"
< 
---
>       module: psutil
>       statement: psutil.__version__
>       version: 5.2.1
810c762
<     type: compile-and-run-gcc-auto
---
>     type: compile-gcc
812c764
<       source: |
---
>       source: |-
823c775
<       cflags_command: "net-snmp-config --agent-libs"
---
>       cflags_command: net-snmp-config --agent-libs
825,826c777,778
<         - "-DNETSNMP_NO_INLINE"
< 
---
>         - -DNETSNMP_NO_INLINE
>       run: true
835,843c787,795
<         - "/Ic:\\snmp\\include"
<         - "/DNETSNMP_NO_INLINE"
<         - "/DWIN32"
<         - "/link"
<         - "/LIBPATH:c:\\snmp\\lib"
<         - "netsnmp.lib"
<         - "netsnmpagent.lib"
<         - "netsnmpmibs.lib"
<       source: |
---
>         - /Ic:\snmp\include
>         - /DNETSNMP_NO_INLINE
>         - /DWIN32
>         - /link
>         - /LIBPATH:c:\snmp\lib
>         - netsnmp.lib
>         - netsnmpagent.lib
>         - netsnmpmibs.lib
>       source: |-
854d805
< 
870c821
<     type: shell-operation
---
>     type: run-bash-script
872,873c823
<       command: "nfsstat --version"
< 
---
>       source: nfsstat --version
894,895c844
<       source: |
<         /opt/node/bin/node --version
---
>       source: /opt/node/bin/node --version
897d845
< 
903,904c851
<       source: |
<         /opt/node/bin/node --version
---
>       source: /opt/node/bin/node --version
906d852
< 
914c860
<     type: shell-operation
---
>     type: run-bash-script
916,919c862,863
<       command: >
<         /cygdrive/c/Program\ Files/nodejs/node.exe --version
<       output: "6.10.2"
< 
---
>       output: 6.10.2
>       source: /cygdrive/c/Program\ Files/nodejs/node.exe --version
940,941c884
<       name: "/usr/local/bin/notary-client.py"
< 
---
>       name: /usr/local/bin/notary-client.py
952,953c895
<       name: "C:\\cygwin\\usr\\local\\bin\\notary-client.py"
< 
---
>       name: C:\cygwin\usr\local\bin\notary-client.py
972c914
<     type: compile-gcc-auto
---
>     type: compile-gcc
974c916
<       source: |
---
>       source: |-
1007d948
< 
1028c969
<     type: compile-gcc-auto
---
>     type: compile-gcc
1030,1031c971,974
<       cflags: ["-lssl", "-lcrypto"]
<       source: |
---
>       cflags:
>         - -lssl
>         - -lcrypto
>       source: |2-
1068d1010
< 
1076,1077c1018
<       output: "1.0.1e-fips"
< 
---
>       output: 1.0.1e-fips
1086,1091c1027,1032
<         - "/Ic:\\openssl\\include"
<         - "/link"
<         - "/LIBPATH:c:\\openssl\\lib"
<         - "libeay32.lib"
<         - "ssleay32.lib"
<       source: |
---
>         - /Ic:\openssl\include
>         - /link
>         - /LIBPATH:c:\openssl\lib
>         - libeay32.lib
>         - ssleay32.lib
>       source: |2-
1128d1068
< 
1132c1072
<     type: shell-operation
---
>     type: run-bash-script
1134,1136c1074,1075
<       command: |
<         SSL_VERSION=`/cygdrive/c/openssl32/openssl-1_0_1t/bin/openssl.exe version | awk '{print $2}'`;if [ $SSL_VERSION = '1.0.1t' ];then exit 0;else exit 1;fi
< 
---
>       source: SSL_VERSION=`/cygdrive/c/openssl32/openssl-1_0_1t/bin/openssl.exe version
>         | awk '{print $2}'`;if [ $SSL_VERSION = '1.0.1t' ];then exit 0;else exit 1;fi
1140c1079
<     type: shell-operation
---
>     type: run-bash-script
1142,1144c1081,1082
<       command: |
<         SSL_VERSION=`/cygdrive/c/openssl32/openssl-1_0_2k/bin/openssl.exe version | awk '{print $2}'`;if [ $SSL_VERSION = '1.0.2k' ];then exit 0;else exit 1;fi
< 
---
>       source: SSL_VERSION=`/cygdrive/c/openssl32/openssl-1_0_2k/bin/openssl.exe version
>         | awk '{print $2}'`;if [ $SSL_VERSION = '1.0.2k' ];then exit 0;else exit 1;fi
1148c1086
<     type: shell-operation
---
>     type: run-bash-script
1150,1152c1088,1089
<       command: |
<         SSL_VERSION=`/cygdrive/c/openssl32/openssl-1_1_0e/bin/openssl.exe version | awk '{print $2}'`;if [ $SSL_VERSION = '1.1.0e' ];then exit 0;else exit 1;fi
< 
---
>       source: SSL_VERSION=`/cygdrive/c/openssl32/openssl-1_1_0e/bin/openssl.exe version
>         | awk '{print $2}'`;if [ $SSL_VERSION = '1.1.0e' ];then exit 0;else exit 1;fi
1158c1095
<     type: shell-operation
---
>     type: run-bash-script
1160,1162c1097,1098
<       command: |
<         SSL_VERSION=`/cygdrive/c/openssl/bin/openssl.exe version | awk '{print $2}'`;if [ $SSL_VERSION = '1.0.2o-fips' ];then exit 0;else exit 1;fi
< 
---
>       source: SSL_VERSION=`/cygdrive/c/openssl/bin/openssl.exe version | awk '{print
>         $2}'`;if [ $SSL_VERSION = '1.0.2o-fips' ];then exit 0;else exit 1;fi
1187c1123
<     type: shell-operation
---
>     type: run-bash-script
1189,1190c1125
<       command: "pip --version"
< 
---
>       source: pip --version
1217,1220c1152,1154
<       module: "poster"
<       statement: "'.'.join([str(i) for i in poster.version])"
<       version: "0.8.1"
< 
---
>       module: poster
>       statement: '''.''.join([str(i) for i in poster.version])'
>       version: 0.8.1
1242,1245c1176,1178
<       module: "Crypto"
<       statement: "Crypto.__version__"
<       version: "2.6.1"
< 
---
>       module: Crypto
>       statement: Crypto.__version__
>       version: 2.6.1
1251,1254c1184,1186
<       module: "six"
<       statement: "six.__version__"
<       version: "1.10.0"
< 
---
>       module: six
>       statement: six.__version__
>       version: 1.10.0
1281,1284c1213,1215
<       module: "pymongo"
<       statement: "pymongo.__version__"
<       version: "3.0.0"
< 
---
>       module: pymongo
>       statement: pymongo.__version__
>       version: 3.0.0
1311,1315c1242,1245
<       module: "pymongo"
<       relationship: "lt"
<       statement: "pymongo.__version__"
<       version: "3.6.0"
< 
---
>       module: pymongo
>       relationship: lt
>       statement: pymongo.__version__
>       version: 3.6.0
1321,1324c1251,1253
<       module: "yaml"
<       statement: "yaml.__version__ + '.0'"
<       version: "3.10.0"
< 
---
>       module: yaml
>       statement: yaml.__version__ + '.0'
>       version: 3.10.0
1331c1260
<     type: shell-operation
---
>     type: run-bash-script
1333c1262
<       command: "/opt/python/2.7/bin/python2 --version"
---
>       source: /opt/python/2.7/bin/python2 --version
1340c1269
<     type: shell-operation
---
>     type: run-bash-script
1342,1343c1271
<       command: "/opt/python/3.6/bin/python3 --version"
< 
---
>       source: /opt/python/3.6/bin/python3 --version
1351c1279
<     type: shell-operation
---
>     type: run-bash-script
1353,1354c1281
<       command: "/cygdrive/c/python/Python36/python.exe --version"
< 
---
>       source: /cygdrive/c/python/Python36/python.exe --version
1362c1289
<     type: shell-operation
---
>     type: run-bash-script
1364,1365c1291
<       command: "/cygdrive/c/python/Python36/python.exe -c 'import nose; print(nose.__version__)'"
< 
---
>       source: /cygdrive/c/python/Python36/python.exe -c 'import nose; print(nose.__version__)'
1373c1299
<     type: shell-operation
---
>     type: run-bash-script
1375,1376c1301
<       command: "/cygdrive/c/python/Python36/python.exe -c 'import winkerberos; print(winkerberos.__version__)'"
< 
---
>       source: /cygdrive/c/python/Python36/python.exe -c 'import winkerberos; print(winkerberos.__version__)'
1384c1309
<     type: shell-operation
---
>     type: run-bash-script
1386,1387c1311
<       command: "/cygdrive/c/python/Python35/python.exe --version"
< 
---
>       source: /cygdrive/c/python/Python35/python.exe --version
1395c1319
<     type: shell-operation
---
>     type: run-bash-script
1397,1398c1321
<       command: "/cygdrive/c/python/Python35/python.exe -c 'import nose; print(nose.__version__)'"
< 
---
>       source: /cygdrive/c/python/Python35/python.exe -c 'import nose; print(nose.__version__)'
1406c1329
<     type: shell-operation
---
>     type: run-bash-script
1408,1409c1331
<       command: "/cygdrive/c/python/Python35/python.exe -c 'import winkerberos; print(winkerberos.__version__)'"
< 
---
>       source: /cygdrive/c/python/Python35/python.exe -c 'import winkerberos; print(winkerberos.__version__)'
1417c1339
<     type: shell-operation
---
>     type: run-bash-script
1419,1420c1341
<       command: "/cygdrive/c/python/Python34/python.exe --version"
< 
---
>       source: /cygdrive/c/python/Python34/python.exe --version
1428c1349
<     type: shell-operation
---
>     type: run-bash-script
1430,1431c1351
<       command: "/cygdrive/c/python/Python34/python.exe -c 'import nose; print(nose.__version__)'"
< 
---
>       source: /cygdrive/c/python/Python34/python.exe -c 'import nose; print(nose.__version__)'
1439c1359
<     type: shell-operation
---
>     type: run-bash-script
1441,1442c1361
<       command: "/cygdrive/c/python/Python34/python.exe -c 'import winkerberos; print(winkerberos.__version__)'"
< 
---
>       source: /cygdrive/c/python/Python34/python.exe -c 'import winkerberos; print(winkerberos.__version__)'
1450c1369
<     type: shell-operation
---
>     type: run-bash-script
1452,1453c1371
<       command: "/cygdrive/c/python/Python33/python.exe --version"
< 
---
>       source: /cygdrive/c/python/Python33/python.exe --version
1461c1379
<     type: shell-operation
---
>     type: run-bash-script
1463,1464c1381
<       command: "/cygdrive/c/python/Python33/python.exe -c 'import nose; print(nose.__version__)'"
< 
---
>       source: /cygdrive/c/python/Python33/python.exe -c 'import nose; print(nose.__version__)'
1472c1389
<     type: shell-operation
---
>     type: run-bash-script
1474,1475c1391
<       command: "/cygdrive/c/python/Python33/python.exe -c 'import winkerberos; print(winkerberos.__version__)'"
< 
---
>       source: /cygdrive/c/python/Python33/python.exe -c 'import winkerberos; print(winkerberos.__version__)'
1483c1399
<     type: shell-operation
---
>     type: run-bash-script
1485,1486c1401
<       command: "/cygdrive/c/python/Python32/python.exe --version"
< 
---
>       source: /cygdrive/c/python/Python32/python.exe --version
1494c1409
<     type: shell-operation
---
>     type: run-bash-script
1496,1497c1411
<       command: "/cygdrive/c/python/Python32/python.exe -c 'import nose; print(nose.__version__)'"
< 
---
>       source: /cygdrive/c/python/Python32/python.exe -c 'import nose; print(nose.__version__)'
1505c1419
<     type: shell-operation
---
>     type: run-bash-script
1507,1508c1421
<       command: "/cygdrive/c/python/Python27/python.exe --version"
< 
---
>       source: /cygdrive/c/python/Python27/python.exe --version
1516c1429
<     type: shell-operation
---
>     type: run-bash-script
1518,1519c1431
<       command: "/cygdrive/c/python/Python27/python.exe -c 'import nose; print(nose.__version__)'"
< 
---
>       source: /cygdrive/c/python/Python27/python.exe -c 'import nose; print(nose.__version__)'
1527c1439
<     type: shell-operation
---
>     type: run-bash-script
1529,1530c1441
<       command: "/cygdrive/c/python/Python27/python.exe -c 'import winkerberos; print(winkerberos.__version__)'"
< 
---
>       source: /cygdrive/c/python/Python27/python.exe -c 'import winkerberos; print(winkerberos.__version__)'
1538c1449
<     type: shell-operation
---
>     type: run-bash-script
1540,1541c1451
<       command: "/cygdrive/c/python/Python26/python.exe --version"
< 
---
>       source: /cygdrive/c/python/Python26/python.exe --version
1549c1459
<     type: shell-operation
---
>     type: run-bash-script
1551,1552c1461
<       command: "/cygdrive/c/python/Python26/python.exe -c 'import nose; print(nose.__version__)'"
< 
---
>       source: /cygdrive/c/python/Python26/python.exe -c 'import nose; print(nose.__version__)'
1560c1469
<     type: shell-operation
---
>     type: run-bash-script
1562,1563c1471
<       command: "/cygdrive/c/python/Python26/python.exe -c 'import winkerberos; print(winkerberos.__version__)'"
< 
---
>       source: /cygdrive/c/python/Python26/python.exe -c 'import winkerberos; print(winkerberos.__version__)'
1571c1479
<     type: shell-operation
---
>     type: run-bash-script
1573,1574c1481
<       command: "/cygdrive/c/python/Python26/python.exe -c 'import unittest2; print(unittest2.__version__)'"
< 
---
>       source: /cygdrive/c/python/Python26/python.exe -c 'import unittest2; print(unittest2.__version__)'
1582c1489
<     type: shell-operation
---
>     type: run-bash-script
1584,1585c1491
<       command: "/cygdrive/c/python/32/Python36/python.exe --version"
< 
---
>       source: /cygdrive/c/python/32/Python36/python.exe --version
1593c1499
<     type: shell-operation
---
>     type: run-bash-script
1595,1596c1501
<       command: "/cygdrive/c/python/32/Python36/python.exe -c 'import nose; print(nose.__version__)'"
< 
---
>       source: /cygdrive/c/python/32/Python36/python.exe -c 'import nose; print(nose.__version__)'
1604c1509
<     type: shell-operation
---
>     type: run-bash-script
1606,1607c1511
<       command: "/cygdrive/c/python/32/Python36/python.exe -c 'import winkerberos; print(winkerberos.__version__)'"
< 
---
>       source: /cygdrive/c/python/32/Python36/python.exe -c 'import winkerberos; print(winkerberos.__version__)'
1615c1519
<     type: shell-operation
---
>     type: run-bash-script
1617,1618c1521
<       command: "/cygdrive/c/python/32/Python35/python.exe --version"
< 
---
>       source: /cygdrive/c/python/32/Python35/python.exe --version
1626c1529
<     type: shell-operation
---
>     type: run-bash-script
1628,1629c1531
<       command: "/cygdrive/c/python/32/Python35/python.exe -c 'import nose; print(nose.__version__)'"
< 
---
>       source: /cygdrive/c/python/32/Python35/python.exe -c 'import nose; print(nose.__version__)'
1637c1539
<     type: shell-operation
---
>     type: run-bash-script
1639,1640c1541
<       command: "/cygdrive/c/python/32/Python35/python.exe -c 'import winkerberos; print(winkerberos.__version__)'"
< 
---
>       source: /cygdrive/c/python/32/Python35/python.exe -c 'import winkerberos; print(winkerberos.__version__)'
1648c1549
<     type: shell-operation
---
>     type: run-bash-script
1650,1651c1551
<       command: "/cygdrive/c/python/32/Python34/python.exe --version"
< 
---
>       source: /cygdrive/c/python/32/Python34/python.exe --version
1659c1559
<     type: shell-operation
---
>     type: run-bash-script
1661,1662c1561
<       command: "/cygdrive/c/python/32/Python34/python.exe -c 'import nose; print(nose.__version__)'"
< 
---
>       source: /cygdrive/c/python/32/Python34/python.exe -c 'import nose; print(nose.__version__)'
1670c1569
<     type: shell-operation
---
>     type: run-bash-script
1672,1673c1571
<       command: "/cygdrive/c/python/32/Python33/python.exe --version"
< 
---
>       source: /cygdrive/c/python/32/Python33/python.exe --version
1681c1579
<     type: shell-operation
---
>     type: run-bash-script
1683,1684c1581
<       command: "/cygdrive/c/python/32/Python33/python.exe -c 'import nose; print(nose.__version__)'"
< 
---
>       source: /cygdrive/c/python/32/Python33/python.exe -c 'import nose; print(nose.__version__)'
1692c1589
<     type: shell-operation
---
>     type: run-bash-script
1694,1695c1591
<       command: "/cygdrive/c/python/32/Python33/python.exe -c 'import winkerberos; print(winkerberos.__version__)'"
< 
---
>       source: /cygdrive/c/python/32/Python33/python.exe -c 'import winkerberos; print(winkerberos.__version__)'
1703c1599
<     type: shell-operation
---
>     type: run-bash-script
1705,1706c1601
<       command: "/cygdrive/c/python/32/Python27/python.exe --version"
< 
---
>       source: /cygdrive/c/python/32/Python27/python.exe --version
1714c1609
<     type: shell-operation
---
>     type: run-bash-script
1716,1717c1611
<       command: "/cygdrive/c/python/32/Python27/python.exe -c 'import nose; print(nose.__version__)'"
< 
---
>       source: /cygdrive/c/python/32/Python27/python.exe -c 'import nose; print(nose.__version__)'
1725c1619
<     type: shell-operation
---
>     type: run-bash-script
1727,1728c1621
<       command: "/cygdrive/c/python/32/Python27/python.exe -c 'import winkerberos; print(winkerberos.__version__)'"
< 
---
>       source: /cygdrive/c/python/32/Python27/python.exe -c 'import winkerberos; print(winkerberos.__version__)'
1736c1629
<     type: shell-operation
---
>     type: run-bash-script
1738,1739c1631
<       command: "/cygdrive/c/python/32/Python26/python.exe --version"
< 
---
>       source: /cygdrive/c/python/32/Python26/python.exe --version
1747c1639
<     type: shell-operation
---
>     type: run-bash-script
1749,1750c1641
<       command: "/cygdrive/c/python/32/Python26/python.exe -c 'import nose; print(nose.__version__)'"
< 
---
>       source: /cygdrive/c/python/32/Python26/python.exe -c 'import nose; print(nose.__version__)'
1758c1649
<     type: shell-operation
---
>     type: run-bash-script
1760,1761c1651
<       command: "/cygdrive/c/python/32/Python26/python.exe -c 'import winkerberos; print(winkerberos.__version__)'"
< 
---
>       source: /cygdrive/c/python/32/Python26/python.exe -c 'import winkerberos; print(winkerberos.__version__)'
1769c1659
<     type: shell-operation
---
>     type: run-bash-script
1771,1772c1661
<       command: "/cygdrive/c/python/32/Python26/python.exe -c 'import unittest2; print(unittest2.__version__)'"
< 
---
>       source: /cygdrive/c/python/32/Python26/python.exe -c 'import unittest2; print(unittest2.__version__)'
1778,1781c1667,1669
<       module: "requests"
<       statement: "requests.__version__"
<       version: "1.1.0"
< 
---
>       module: requests
>       statement: requests.__version__
>       version: 1.1.0
1785c1673
<     type: shell-operation
---
>     type: run-bash-script
1787,1788c1675
<       command: "rsync --version"
< 
---
>       source: rsync --version
1809c1696
<     type: shell-operation
---
>     type: run-bash-script
1811,1812c1698
<       command: "saslauthd -v"
< 
---
>       source: saslauthd -v
1833c1719
<     type: compile-gcc-auto
---
>     type: compile-gcc
1835c1721
<       source: |
---
>       source: |-
1877d1762
< 
1902c1787
<     type: shell-operation
---
>     type: run-bash-script
1904,1907c1789,1790
<       command: >
<         scons --version | grep script | sed -n 's/.*\([[:digit:]]\.[[:digit:]]\.[[:digit:]]\).*/\1/p'
<       output: "2.4.1"
< 
---
>       output: 2.4.1
>       source: scons --version | grep script | sed -n 's/.*\([[:digit:]]\.[[:digit:]]\.[[:digit:]]\).*/\1/p'
1911c1794
<     type: shell-operation
---
>     type: run-bash-script
1913,1916c1796,1797
<       command: >
<         scons --version | grep script | sed -n 's/.*\([[:digit:]]\.[[:digit:]]\.[[:digit:]]\).*/\1/p'
<       output: "2.3.0"
< 
---
>       output: 2.3.0
>       source: scons --version | grep script | sed -n 's/.*\([[:digit:]]\.[[:digit:]]\.[[:digit:]]\).*/\1/p'
1937,1941c1818,1820
<       module: "subprocess32"
<       statement: "'0.0.0'"
<       version: "0.0.0"
< 
< 
---
>       module: subprocess32
>       statement: '''0.0.0'''
>       version: 0.0.0
1957,1958c1836
<       name: "/opt/mongodbtoolchain/v1"
< 
---
>       name: /opt/mongodbtoolchain/v1
1964,1965c1842
<       name: "libtoolize --version"
< 
---
>       name: libtoolize --version
1984,1985c1861
<       name: "/opt/mongodbtoolchain/v2"
< 
---
>       name: /opt/mongodbtoolchain/v2
1991,1992c1867
<       name: "libtoolize --version"
< 
---
>       name: libtoolize --version
2016d1890
<       # pass a negative number to get the default max
2018d1891
< 
2043d1915
< 
2067c1939
<     type: shell-operation
---
>     type: run-bash-script
2069,2070c1941
<       command: "virtualenv --version"
< 
---
>       source: virtualenv --version
2094,2095c1965
<       name: "/sbin/mkfs.xfs"
< 
---
>       name: /sbin/mkfs.xfs
2100c1970
<     type: shell-operation
---
>     type: run-bash-script
2102,2103c1972
<       command: "aws --version"
< 
---
>       source: aws --version
2111c1980
<     type: shell-operation
---
>     type: run-bash-script
2113,2116c1982,1983
<       command: >
<         clang --version | grep LLVM | sed -n 's/.*version \([[:digit:]]\.[[:digit:]]\.[[:digit:]]\).*/\1/p'
<       output: "3.5.0"
< 
---
>       output: 3.5.0
>       source: clang --version | grep LLVM | sed -n 's/.*version \([[:digit:]]\.[[:digit:]]\.[[:digit:]]\).*/\1/p'
2129c1996
<     type: shell-operation
---
>     type: run-bash-script
2131,2132c1998
<       command: "cmake --version || /opt/cmake/bin/cmake --version"
< 
---
>       source: cmake --version || /opt/cmake/bin/cmake --version
2140,2141c2006
<       name: "c:\\cmake\\bin\\cmake.exe"
< 
---
>       name: c:\cmake\bin\cmake.exe
2147c2012
<     type: shell-operation
---
>     type: run-bash-script
2149,2150c2014
<       command: "dos2unix --version"
< 
---
>       source: dos2unix --version
2168,2172c2032,2035
<       commands:
<         - command: "dpkg-buildpackage --version"
<         - command: "dpkg-scanpackages --version"
<         - command: "apt-ftparchive --version"
< 
---
>       source: |-
>         dpkg-buildpackage --version
>         dpkg-scanpackages --version
>         apt-ftparchive --version
2179c2042
<     type: shell-operation
---
>     type: run-bash-script
2181,2182c2044
<       command: "emacs --version"
< 
---
>       source: emacs --version
2190d2051
< 
2209c2070
<       source: |
---
>       source: |-
2217d2077
< 
2222c2082
<     type: shell-operation
---
>     type: run-bash-script
2224,2225c2084
<       command: "gnuplot --version"
< 
---
>       source: gnuplot --version
2229c2088
<     type: shell-operation
---
>     type: run-bash-script
2231,2232c2090
<       command: "go version"
< 
---
>       source: go version
2244d2101
< 
2249c2106
<     type: shell-operation
---
>     type: run-bash-script
2251,2252c2108
<       command: "lcov --version"
< 
---
>       source: lcov --version
2257c2113
<     type: shell-operation
---
>     type: run-bash-script
2259,2260c2115
<       command: "lein --version"
< 
---
>       source: lein --version
2269d2123
< 
2277d2130
< 
2286d2138
< 
2288c2140,2141
<     suites: ["linux"]
---
>     suites:
>       - linux
2291,2292c2144
<       name: "/usr/include/pcap.h"
< 
---
>       name: /usr/include/pcap.h
2298,2299c2150
<       name: "/usr/lib/libxmlsec1.so.1"
< 
---
>       name: /usr/lib/libxmlsec1.so.1
2308d2158
< 
2312c2162
<     type: shell-operation
---
>     type: run-bash-script
2314,2315c2164
<       command: "lxc-info --version"
< 
---
>       source: lxc-info --version
2324,2325c2173
<       name: "/usr/bin/python"
< 
---
>       name: /usr/bin/python
2334,2335c2182
<       name: "/usr/bin/strip"
< 
---
>       name: /usr/bin/strip
2342,2343c2189
<       name: "/opt/packer/packer"
< 
---
>       name: /opt/packer/packer
2350c2196
<       source: |
---
>       source: |-
2354,2355c2200
<       output: "1.2.0"
< 
---
>       output: 1.2.0
2362,2364c2207,2208
<       source: "uname -r"
<       output: "3.10.0-327.22.2.el7.x86_64"
< 
---
>       source: uname -r
>       output: 3.10.0-327.22.2.el7.x86_64
2376,2380c2220,2223
<       commands:
<         - command: "createrepo --version"
<         - command: "rpmbuild --version"
<         - command: "rpm --version"
< 
---
>       source: |-
>         createrepo --version
>         rpmbuild --version
>         rpm --version
2388c2231
<     type: shell-operation
---
>     type: run-bash-script
2390,2392c2233
<       command: "rvm --version"
< 
<   # An "additional ruby" only installed on certain platforms
---
>       source: rvm --version
2398c2239
<     type: shell-operation
---
>     type: run-bash-script
2400,2402c2241
<       command: "$HOME/.rvm/rubies/ruby-1.9*/bin/ruby -e 'puts'"
< 
<   # An "additional ruby" only installed on certain platforms
---
>       source: $HOME/.rvm/rubies/ruby-1.9*/bin/ruby -e 'puts'
2408c2247
<     type: shell-operation
---
>     type: run-bash-script
2410,2412c2249
<       command: "$HOME/.rvm/rubies/ruby-2.3*/bin/ruby -e 'puts'"
< 
<   # An "additional ruby" only installed on certain platforms
---
>       source: $HOME/.rvm/rubies/ruby-2.3*/bin/ruby -e 'puts'
2418c2255
<     type: shell-operation
---
>     type: run-bash-script
2420,2422c2257
<       command: "$HOME/.rvm/rubies/ruby-2.4*/bin/ruby -e 'puts'"
< 
<   # The "default ruby" installed on primary ruby driver toolchain platforms
---
>       source: $HOME/.rvm/rubies/ruby-2.4*/bin/ruby -e 'puts'
2430c2265
<     type: shell-operation
---
>     type: run-bash-script
2432,2433c2267
<       command: "$HOME/.rvm/rubies/ruby-2.5*/bin/ruby -e 'puts'"
< 
---
>       source: $HOME/.rvm/rubies/ruby-2.5*/bin/ruby -e 'puts'
2439c2273
<     type: shell-operation
---
>     type: run-bash-script
2441,2442c2275
<       command: "$HOME/.rvm/rubies/jruby-1.7*/bin/ruby -e 'puts'"
< 
---
>       source: $HOME/.rvm/rubies/jruby-1.7*/bin/ruby -e 'puts'
2449c2282
<     type: shell-operation
---
>     type: run-bash-script
2451,2452c2284
<       command: "$HOME/.rvm/rubies/jruby-9.1*/bin/ruby -e 'puts'"
< 
---
>       source: $HOME/.rvm/rubies/jruby-9.1*/bin/ruby -e 'puts'
2467c2299
<     type: shell-operation
---
>     type: run-bash-script
2469,2470c2301
<       command: "sudo date"
< 
---
>       source: sudo date
2485c2316
<     type: shell-operation
---
>     type: run-bash-script
2487,2488c2318
<       command: "sudo dmesg"
< 
---
>       source: sudo dmesg
2495c2325
<     type: run-program-system-python
---
>     type: run-python-source
2497c2327
<       source: |
---
>       source: |-
2504,2505c2334,2335
<       output: "success"
< 
---
>       output: success
>       interpreter: C:\Python36\python.exe
2517d2346
< 
2527d2355
< 
2534d2361
< 
2542d2368
< 
2546c2372
<     type: run-program-system-python2
---
>     type: run-python-source
2548c2374
<       source: |
---
>       source: |-
2557c2383
< 
---
>       interpreter: python2
2580,2581c2406
<       name: "/usr/include/pcap.h"
< 
---
>       name: /usr/include/pcap.h
2604,2605c2429
<       name: "/usr/bin/sar"
< 
---
>       name: /usr/bin/sar
2629,2630c2453
<       name: "/etc/mongodb-distro-name"
< 
---
>       name: /etc/mongodb-distro-name
2641,2642c2464
<       name: "c:/mongodb-distro-name"
< 
---
>       name: c:/mongodb-distro-name
2667c2489
<     type: shell-operation
---
>     type: run-bash-script
2669,2670c2491
<       command: "which screen"
< 
---
>       source: which screen
2675c2496
<     type: shell-operation
---
>     type: run-bash-script
2677,2678c2498
<       command: "dpkg -s libc6 | grep Version: | grep -v 2.23-0ubuntu3"
< 
---
>       source: 'dpkg -s libc6 | grep Version: | grep -v 2.23-0ubuntu3'
2685,2687c2505,2506
<       source: "ant -version"
<       output: "Apache Ant(TM) version 1.10.1 compiled on February 2 2017"
< 
---
>       source: ant -version
>       output: Apache Ant(TM) version 1.10.1 compiled on February 2 2017
2693c2512
<       source: |
---
>       source: |-
2701d2519
< 
2706c2524
<     type: shell-operation
---
>     type: run-bash-script
2708,2711c2526,2527
<       command: >
<         clang --version | grep LLVM | sed -n 's/.*version \([[:digit:]]\.[[:digit:]]\.[[:digit:]]\).*/\1/p'
<       output: "3.7.0"
< 
---
>       output: 3.7.0
>       source: clang --version | grep LLVM | sed -n 's/.*version \([[:digit:]]\.[[:digit:]]\.[[:digit:]]\).*/\1/p'
2719c2535
<     type: run-program-system-python
---
>     type: run-python-source
2721c2537
<       source: |
---
>       source: |-
2728,2729c2544
<       output: "success"
< 
---
>       output: success
2743c2558
<       source: |
---
>       source: |-
2746,2747c2561
<       output: "9"
< 
---
>       output: '9'
2764c2578
<       source: |
---
>       source: |-
2767,2768c2581
<       output: "1.8.0_162"
< 
---
>       output: 1.8.0_162
2782c2595
<       source: |
---
>       source: |-
2785,2786c2598
<       output: "1.7.0_79"
< 
---
>       output: 1.7.0_79
2800c2612
<       source: |
---
>       source: |-
2803,2804c2615
<       output: "1.6.0_45"
< 
---
>       output: 1.6.0_45
2818c2629
<       source: |
---
>       source: |-
2821,2822c2632
<       output: "1.5.0_22"
< 
---
>       output: 1.5.0_22
2828c2638
<     type: run-program-system-python
---
>     type: run-python-source
2830c2640
<       source: |
---
>       source: |-
2838,2839c2648,2649
<       output: "9"
< 
---
>       output: '9'
>       interpreter: C:\Python36\python.exe
2845c2655
<     type: run-program-system-python
---
>     type: run-python-source
2847c2657
<       source: |
---
>       source: |-
2855c2665,2666
<       output: "1.8.0_162"
---
>       output: 1.8.0_162
>       interpreter: C:\Python36\python.exe
2861c2672
<     type: run-program-system-python
---
>     type: run-python-source
2863c2674
<       source: |
---
>       source: |-
2871c2682,2683
<       output: "1.7.0_80"
---
>       output: 1.7.0_80
>       interpreter: C:\Python36\python.exe
2877c2689
<     type: run-program-system-python
---
>     type: run-python-source
2879c2691
<       source: |
---
>       source: |-
2887c2699,2700
<       output: "1.6.0_45"
---
>       output: 1.6.0_45
>       interpreter: C:\Python36\python.exe
2893c2706
<     type: run-program-system-python
---
>     type: run-python-source
2895c2708
<       source: |
---
>       source: |-
2903,2904c2716,2717
<       output: "1.5.0_22"
< 
---
>       output: 1.5.0_22
>       interpreter: C:\Python36\python.exe
2918c2731
<     type: shell-operation
---
>     type: run-bash-script
2920,2921c2733,2734
<       command: "ANT_HOME=/opt/java/ant/bin/ant.bat JAVA_HOME=/opt/java/jdk8 /opt/java/ant/bin/ant -version"
< 
---
>       source: ANT_HOME=/opt/java/ant/bin/ant.bat JAVA_HOME=/opt/java/jdk8 /opt/java/ant/bin/ant
>         -version
2927c2740
<     type: shell-operation
---
>     type: run-bash-script
2929,2930c2742,2743
<       command: "ANT_HOME=/cygdrive/c/java/ant/bin/ant.bat JAVA_HOME=/cygdrive/c/java/jdk8 /cygdrive/c/java/ant/bin/ant -version"
< 
---
>       source: ANT_HOME=/cygdrive/c/java/ant/bin/ant.bat JAVA_HOME=/cygdrive/c/java/jdk8
>         /cygdrive/c/java/ant/bin/ant -version
2944d2756
< 
2950,2951c2762
<       name: "c:\\Program Files\\dotnet\\dotnet.exe"
< 
---
>       name: c:\Program Files\dotnet\dotnet.exe
2957,2958c2768
<       name: "c:\\Program Files (x86)\\Common Files\\Microsoft\\Visual C++ for Python\\9.0\\vcvarsall.bat"
< 
---
>       name: c:\Program Files (x86)\Common Files\Microsoft\Visual C++ for Python\9.0\vcvarsall.bat
2966d2775
< 
2976c2785
<     type: shell-operation
---
>     type: run-bash-script
2978,2980c2787
<       command: |
<         /sbin/ldconfig -p | grep -Eq '^\s*libunwind.so '
< 
---
>       source: /sbin/ldconfig -p | grep -Eq '^\s*libunwind.so '
2985c2792
<     type: shell-operation
---
>     type: run-bash-script
2987,2989c2794
<       command: |
<         x86_64-w64-mingw32-gcc --version
< 
---
>       source: x86_64-w64-mingw32-gcc --version
2998d2802
< 
3006,3007c2810
<       name: "/opt/java/"
< 
---
>       name: /opt/java/
3014,3015c2817
<       name: "/opt/perl"
< 
---
>       name: /opt/perl
3023,3024c2825
<       name: "c:\\perl"
< 
---
>       name: c:\perl
3041c2842
<     type: shell-operation
---
>     type: run-bash-script
3043,3045c2844
<       command: |
<         unzip -v
< 
---
>       source: unzip -v
3068c2867
<     type: run-program-system-python
---
>     type: run-python-source
3070c2869
<       source: |
---
>       source: |-
3082,3083c2881
<       output: "success"
< 
---
>       output: success
3087c2885
<     type: shell-operation
---
>     type: run-bash-script
3089,3090c2887
<       command: "test -e $HOME/.evergreen.yml"
< 
---
>       source: test -e $HOME/.evergreen.yml
3095c2892
<     type: shell-operation
---
>     type: run-bash-script
3097,3098c2894
<       command: "R --version"
< 
---
>       source: R --version
3103c2899
<     type: shell-operation
---
>     type: run-bash-script
3105,3107c2901
<       command: "fc-list | grep -q \"Ubuntu Mono\""
< 
<   # keep at bottom of file, since it confuses some syntax highlighters
---
>       source: fc-list | grep -q "Ubuntu Mono"
3116,3120c2910,2914
<         - "/Ic:\\sasl\\include"
<         - "/link"
<         - "/LIBPATH:c:\\sasl\\lib"
<         - "sasl2.lib"
<       source: |
---
>         - /Ic:\sasl\include
>         - /link
>         - /LIBPATH:c:\sasl\lib
>         - sasl2.lib
>       source: |-
3158d2951
< 
3162c2955
<     type: shell-operation
---
>     type: run-bash-script
3164,3165c2957
<       command: "/opt/csw/bin/pkgutil -l | grep sasl-dev"
< 
---
>       source: /opt/csw/bin/pkgutil -l | grep sasl-dev
3169c2961
<     type: shell-operation
---
>     type: run-bash-script
3171,3173c2963,2964
<       command: |
<         REG QUERY 'HKEY_LOCAL_MACHINE\\Software\\Classes\\Installer\\Patches\\468669FE9E07E3F428C6C67A022B3F0E\\SourceList' | grep -q 4020481
< 
---
>       source: REG QUERY 'HKEY_LOCAL_MACHINE\\Software\\Classes\\Installer\\Patches\\468669FE9E07E3F428C6C67A022B3F0E\\SourceList'
>         | grep -q 4020481
3181c2972
<     type: shell-operation
---
>     type: run-bash-script
3183,3184c2974
<       command: "certutil.exe -store root | grep 'DigiCert Global Root CA'"
< 
---
>       source: certutil.exe -store root | grep 'DigiCert Global Root CA'
3189c2979
<     type: shell-operation
---
>     type: run-bash-script
3191,3192c2981
<       command: "google-chrome --version"
< 
---
>       source: google-chrome --version
3196c2985
<     type: shell-operation
---
>     type: run-bash-script
3198,3199c2987
<       command: "chromium --version"
< 
---
>       source: chromium --version
3204c2992
<     type: shell-operation
---
>     type: run-bash-script
3206,3207c2994
<       command: "grep user_allow_other /etc/fuse.conf | egrep -v '^#'"
< 
---
>       source: grep user_allow_other /etc/fuse.conf | egrep -v '^#'
3212c2999
<     type: shell-operation
---
>     type: run-bash-script
3214,3215c3001
<       command: "ifconfig --version"
< 
---
>       source: ifconfig --version
3219c3005
<     type: shell-operation
---
>     type: run-bash-script
3221,3222c3007
<       command: "xvfb-run -h"
< 
---
>       source: xvfb-run -h
3239c3024
<     type: shell-operation
---
>     type: run-bash-script
3241,3243c3026
<       command: |
<         patch --version
< 
---
>       source: patch --version
3260c3043
<     type: shell-operation
---
>     type: run-bash-script
3262,3264c3045
<       command: |
<         makeinfo --version
< 
---
>       source: makeinfo --version
3281c3062
<     type: shell-operation
---
>     type: run-bash-script
3283,3286c3064
<       # There are two versions of ncurses 5 on debian/ubuntu and 6 on rhel/amz
<       command: |
<         ncurses6-config --version || ncurses5-config --version
< 
---
>       source: ncurses6-config --version || ncurses5-config --version
3303,3304c3081
<       name: "/usr/include/curl/curl.h"
< 
---
>       name: /usr/include/curl/curl.h
3311,3312c3088
<       name: "/usr/include/x86_64-linux-gnu/curl/curl.h"
< 
---
>       name: /usr/include/x86_64-linux-gnu/curl/curl.h
3331,3332c3107
<       name: "/usr/bin/kinit"
< 
---
>       name: /usr/bin/kinit
3338,3339c3113
<       name: "/etc/apt/apt.conf.d/20auto-upgrades"
< 
---
>       name: /etc/apt/apt.conf.d/20auto-upgrades
3347,3348c3121
<       name: "/etc/sysctl.d/ptrace_scope.conf"
< 
---
>       name: /etc/sysctl.d/ptrace_scope.conf
3352c3125
<     type: shell-operation
---
>     type: run-bash-script
3354,3355c3127
<       command: "/opt/swift-4.1-RELEASE-ubuntu16.04/usr/bin/swift --version"
< 
---
>       source: /opt/swift-4.1-RELEASE-ubuntu16.04/usr/bin/swift --version
3362d3133
< 
3369d3139
< 
3376d3145
< 
3383d3151
< 
3390d3157
< 
3397d3163
< 
3404d3169
< 
3411d3175
< 
3415c3179
<     type: shell-operation
---
>     type: run-bash-script
3417,3418c3181
<       command: "kitchen --version"
< 
---
>       source: kitchen --version
3424c3187
<     type: shell-operation
---
>     type: run-bash-script
3426,3427c3189
<       command: "pip list | grep pywin32"
< 
---
>       source: pip list | grep pywin32
3433c3195
<     type: shell-operation
---
>     type: run-bash-script
3435,3436c3197
<       command: "pip list | grep pypiwin32"
< 
---
>       source: pip list | grep pypiwin32
3442c3203
<     type: shell-operation
---
>     type: run-bash-script
3444,3445c3205
<       command: "pip list | grep PyKMIP"
< 
---
>       source: pip list | grep PyKMIP
3452c3212
<     type: shell-operation
---
>     type: run-bash-script
3454,3455c3214
<       command: "7z.exe"
< 
---
>       source: 7z.exe
3462c3221
<     type: shell-operation
---
>     type: run-bash-script
3464,3465c3223
<       command: "/cygdrive/c/Progra~2/7-Zip/7z.exe"
< 
---
>       source: /cygdrive/c/Progra~2/7-Zip/7z.exe
3473c3231
<     type: shell-operation
---
>     type: run-bash-script
3475,3476c3233
<       command: "bcdedit"
< 
---
>       source: bcdedit
3480c3237
<     type: run-program-system-python
---
>     type: run-python-source
3482c3239
<       source: |
---
>       source: |-
3492,3493c3249
<       output: "1.0.1e"
< 
---
>       output: 1.0.1e
3497c3253
<     type: run-program-system-python
---
>     type: run-python-source
3499c3255
<       source: |
---
>       source: |-
3509,3510c3265
<       output: "1.0.1e"
< 
---
>       output: 1.0.1e
3514c3269
<     type: run-program-system-python
---
>     type: run-python-source
3516c3271
<       source: |
---
>       source: |-
3526,3527c3281
<       output: "7.29.0"
< 
---
>       output: 7.29.0
3531c3285
<     type: run-program-system-python
---
>     type: run-python-source
3533c3287
<       source: |
---
>       source: |-
3543,3544c3297
<       output: "2.1.26"
< 
---
>       output: 2.1.26
3548c3301
<     type: run-program-system-python
---
>     type: run-python-source
3550c3303
<       source: |
---
>       source: |-
3560,3561c3313
<       output: "1.15.1"
< 
---
>       output: 1.15.1
3565c3317
<     type: run-program-system-python
---
>     type: run-python-source
3567c3319
<       source: |
---
>       source: |-
3577,3578c3329
<       output: "2.4.44"
< 
---
>       output: 2.4.44
3582c3333
<     type: run-program-system-python
---
>     type: run-python-source
3584c3335
<       source: |
---
>       source: |-
3594,3595c3345
<       output: "5.7.2"
< 
---
>       output: 5.7.2
3600c3350
<     type: shell-operation
---
>     type: run-bash-script
3602c3352
<       command: "cat /etc/redhat-release | awk '{print $(NF-1)}' | grep 7.0"
---
>       source: cat /etc/redhat-release | awk '{print $(NF-1)}' | grep 7.0
```