### PR TITLE
Add compile-visual-studio check as well as some minor bug fixes for other checks Windows compatibility

### DIFF
--- a/checks/compile_gcc.go
+++ b/checks/compile_gcc.go
@@ -1,7 +1,6 @@
 // Copyright 2018 Mathew Robinson <chasinglogic@gmail.com>. All rights reserved. Use of this source code is
 // governed by the Apache-2.0 license that can be found in the LICENSE file.
 
-
 package checks
 
 import (
@@ -31,10 +30,11 @@ func init() {
 //   - Windows
 //
 // Arguments:
-//   source (required): The source code of the script.
-//   compiler: path to the compiler. Default is 'gcc' from the PATH
+//   source (required): The source code to compile.
+//   compiler: path to the compiler. Default is 'gcc' from the $PATH
 //   cflags: compiles flags, string, e.g "-lss -lsasl2"
 //   cflags_command: command to get clags, e.g. "net-snmp-config --agent-libs"
+//   run: If true try running the compiled binary
 type CompileGcc struct {
 	Source        string
 	Compiler      string

--- a/checks/compile_gcc_test.go
+++ b/checks/compile_gcc_test.go
@@ -4,10 +4,17 @@
 package checks
 
 import (
+	"os/exec"
 	"testing"
 )
 
 func TestCompileGcc(t *testing.T) {
+	// First make sure gcc is in the PATH
+	// Don't run these tests unless you are on a system with gcc installed
+	_, err := exec.LookPath("gcc")
+	if err != nil {
+		return
+	}
 
 	tests := checkerTests{
 		{

--- a/checks/compile_visual_studio_windows.go
+++ b/checks/compile_visual_studio_windows.go
@@ -1,0 +1,241 @@
+package checks
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"text/template"
+
+	"github.com/google/shlex"
+	"golang.org/x/sys/windows/registry"
+)
+
+func init() {
+	availableChecks["compile-visual-studio"] = CompileVisualStudioFromArgs
+}
+
+// CompileVisualStudio runs VisualStudio compile.
+//
+// Type:
+//	 - compile-visual-studio
+//
+// Support Platforms:
+//   - Windows
+//
+// Arguments:
+//   source (required): The source code to comipile.
+//   cflags: A string that will be parsed using shlex and passed as arguments to cl.exe
+//   version: Visual studio version to use. Default is the latest version installed on the system
+//   extension: The file extension to use for the generated temporary file. Default is "cpp"
+//   run: If true try running the compiled binary
+//   compiler: A string path to the compiler to use. This is a template that gets
+// 	           one variable: '{{ .VisualStudioPath }}' which is the path to the
+//             Visual Studio installation we are using, ending with the filepath separator
+//             '\'. For example for VS2015 it would be:
+//
+// 	           C:\Program Files (x86)\Microsoft Visual Studio 14.0\
+//
+// 	           This allows you to specify compilers other than VC\bin\cl.exe to use.
+// 	           For example if you wanted to compile C#. You can pass a hardcoded string here
+// 	           without the template variable if you wish to specify a full path and
+// 	           bypass our VisualStudio installation detection logic.
+//
+// 	           This defaults to "{{ .VisualStudioPath }}VC\\bin\\cl.exe"
+//
+// Notes:
+//   For the version argument you can either specify the year (2015) or the actual
+//   version number as recognized by Visual Studio registry entries (14.0) and
+//   this check will do the math to figure out what you want.
+type CompileVisualStudio struct {
+	Source    string
+	Cflags    string
+	Version   float64
+	Extension string
+	Compiler  string
+	Run       bool
+}
+
+func getRealVersionNumber(version float64) float64 {
+	s := strconv.FormatFloat(version, 'f', -1, 64)
+	// If the version is 4 digits long it's assumed to be a year
+	if len(s) == 4 {
+		year := int(version)
+		// 2010 was version 10.0 then they waited 3 years to release version 12.0
+		if year == 2010 {
+			return 10.0
+		}
+
+		// 2013 and 2015 were the first "2 year cadence" releases and were
+		// increased two version numbers per release
+		if year <= 2015 {
+			return 10.0 + float64(year-2011)
+		}
+
+		// After 2015 came 2017 (latest at the time of this writing) despite being
+		// released 2 years after 2015 it was only bumped one version number (15.0)
+		// this code assumes they'll be consistent and keep going up by one
+		// every two years, when 2019 drops we may need to update this function
+		// again.
+		return 14.0 + float64((year-2015)/2)
+	}
+
+	return version
+}
+
+const visualStudioRegPath = "SOFTWARE\\Wow6432Node\\Microsoft\\VisualStudio\\SxS\\VS7"
+
+func findVisualStudio(version float64) (string, error) {
+	// Convert a year, if given, to a known visual studio version number
+	realVersionNumber := getRealVersionNumber(version)
+	key, err := registry.OpenKey(
+		registry.LOCAL_MACHINE, visualStudioRegPath, registry.QUERY_VALUE)
+	if err != nil {
+		return "", fmt.Errorf("unable to open registry: %s: %s", visualStudioRegPath, err)
+	}
+
+	defer key.Close()
+
+	// If version specified just get it
+	if version != 0.0 {
+		versionString := strconv.FormatFloat(realVersionNumber, 'f', 1, 64)
+		val, _, err := key.GetStringValue(versionString)
+		return val, err
+	}
+
+	installedVersions, err := key.ReadValueNames(-1)
+	if err != nil {
+		return "", fmt.Errorf("Unable to read installed Visual Studio verisons: %s", err)
+	}
+
+	sort.Strings(installedVersions)
+
+	val, _, err := key.GetStringValue(installedVersions[len(installedVersions)-1])
+	return val, err
+}
+
+// Check compiles, and optionally runs, code using VisualStudio
+func (cvs CompileVisualStudio) Check() error {
+	vsPath, err := findVisualStudio(cvs.Version)
+	if err != nil {
+		return fmt.Errorf("Problem finding Visual Studio: %s", err)
+	}
+
+	tmpfolder, err := ioutil.TempDir("", "compileVisualStudio_")
+	if err != nil {
+		return fmt.Errorf("Problem creating a tmpdir: %s", err)
+	}
+
+	// defer os.RemoveAll(tmpfolder)
+
+	if cvs.Extension == "" {
+		cvs.Extension = "cpp"
+	}
+
+	srcfileName := filepath.Join(tmpfolder, "src."+cvs.Extension)
+	outfileName := filepath.Join(tmpfolder, "out.exe")
+
+	srcfile, err := os.Create(srcfileName)
+	if err != nil {
+		return fmt.Errorf("Problem creating a srcfile: %s", err)
+	}
+
+	cvs.Source = strings.Replace(cvs.Source, "\n", "\r\n", -1)
+	content := []byte(cvs.Source)
+
+	if _, err := srcfile.Write(content); err != nil {
+		return fmt.Errorf("Problem writing to a tmpfile: %s", err)
+	}
+
+	if err := srcfile.Close(); err != nil {
+		return fmt.Errorf("Problem closing the tmpfile: %s", err)
+	}
+
+	compileCommandTemplate := template.New("compileCommand")
+	if cvs.Compiler == "" {
+		compileCommandTemplate, err = compileCommandTemplate.Parse("{{ .VisualStudioPath }}VC\\bin\\cl.exe")
+	} else {
+		compileCommandTemplate, err = compileCommandTemplate.Parse(cvs.Compiler)
+	}
+
+	if err != nil {
+		return fmt.Errorf("Problem parsing compileCommand template: %s", err)
+	}
+
+	buffer := &bytes.Buffer{}
+	err = compileCommandTemplate.Execute(buffer, struct {
+		VisualStudioPath string
+	}{
+		VisualStudioPath: vsPath,
+	})
+
+	if err != nil {
+		return fmt.Errorf("Problem compiling compileCommand template: %s", err)
+	}
+
+	argv := []string{fmt.Sprintf("/Fo%s", outfileName)}
+	if cvs.Cflags != "" {
+		flags, err := shlex.Split(cvs.Cflags)
+		if err != nil {
+			return fmt.Errorf("Unable to parse cflags: %s", err)
+		}
+
+		argv = append(argv, flags...)
+	}
+
+	argv = append(argv, srcfileName)
+	compileCommand := fmt.Sprintf(`"%s" %s`, buffer.String(), strings.Join(argv, " "))
+	envScript := fmt.Sprintf(`"%sVC\bin\vcvars32.bat"`, vsPath)
+
+	compileScript, err := os.Create(filepath.Join(tmpfolder, "compile.bat"))
+	if err != nil {
+		return fmt.Errorf("Problem creating batch script: %s", err)
+	}
+
+	scriptBody := fmt.Sprintf(`call %s
+if %%errorlevel%% neq 0 exit /b %%errorlevel%%
+call %s
+if %%errorlevel%% neq 0 exit /b %%errorlevel%%`, envScript, compileCommand)
+
+	_, err = compileScript.Write([]byte(scriptBody))
+	if err != nil {
+		return fmt.Errorf("Problem writing batch script: %s", err)
+	}
+
+	cmd := exec.Command("cmd.exe", "/c", filepath.Join(tmpfolder, "compile.bat"))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("Problem running the Visual Studio compile: %s: %s", err, string(out))
+	}
+
+	if cvs.Run {
+		cmd = exec.Command(outfileName)
+		out, err = cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("Problem running compiled executable: %s: %s", err, string(out))
+		}
+	}
+
+	return nil
+}
+
+// CompileVisualStudioFromArgs will populate the CompileVisualStudio with the args given in the
+// tests YAML config
+func CompileVisualStudioFromArgs(args Args) (Checker, error) {
+	cg := CompileVisualStudio{}
+
+	if err := requiredArgs(args, "source"); err != nil {
+		return nil, err
+	}
+
+	if err := decodeFromArgs(args, &cg); err != nil {
+		return nil, err
+	}
+
+	return cg, nil
+}

--- a/checks/compile_visual_studio_windows.go
+++ b/checks/compile_visual_studio_windows.go
@@ -29,7 +29,7 @@ func init() {
 //   - Windows
 //
 // Arguments:
-//   source (required): The source code to comipile.
+//   source (required): The source code to compile.
 //   cflags: A string that will be parsed using shlex and passed as arguments to cl.exe
 //   version: Visual studio version to use. Default is the latest version installed on the system
 //   extension: The file extension to use for the generated temporary file. Default is "cpp"

--- a/checks/compile_visual_studio_windows_test.go
+++ b/checks/compile_visual_studio_windows_test.go
@@ -1,0 +1,87 @@
+package checks
+
+import "testing"
+
+func TestRealVersionNumber(t *testing.T) {
+	version := getRealVersionNumber(2010.0)
+	if version != 10.0 {
+		t.Errorf("Expected %f Got %f", 10.0, version)
+	}
+
+	version = getRealVersionNumber(10.0)
+	if version != 10.0 {
+		t.Errorf("Expected %f Got %f", 10.0, version)
+	}
+
+	version = getRealVersionNumber(2013.0)
+	if version != 12.0 {
+		t.Errorf("Expected %f Got %f", 12.0, version)
+	}
+
+	version = getRealVersionNumber(2015.0)
+	if version != 14.0 {
+		t.Errorf("Expected %f Got %f", 14.0, version)
+	}
+
+	version = getRealVersionNumber(2017.0)
+	if version != 15.0 {
+		t.Errorf("Expected %f Got %f", 15.0, version)
+	}
+
+	// Hopefully they'll only increment by one again for the next one.
+	version = getRealVersionNumber(2019.0)
+	if version != 16.0 {
+		t.Errorf("Expected %f Got %f", 16.0, version)
+	}
+}
+
+func TestCompileVisualStudio(t *testing.T) {
+	tests := checkerTests{
+		{
+			Name: "visual-studio compile hello world",
+			Args: Args{
+				"source": `#include <iostream>
+
+				int main() {
+					std::cout << "Hello world!" << std::endl;
+				}`,
+			},
+		},
+		{
+			Name: "visual-studio compile bad hello world",
+			Args: Args{
+				"source": `include <iostream>
+
+				int main() {
+					std::cout << "Hello world!" << std::endl;
+				}`,
+			},
+			ShouldError: true,
+		},
+		{
+			Name: "visual-studio compile hello world with args",
+			Args: Args{
+				"source": `#include <iostream>
+
+				int main() {
+					std::cout << "Hello world!" << std::endl;
+				}`,
+				"cflags": "/O1",
+			},
+		},
+		{
+			Name: "visual-studio compile hello world with bad args",
+			Args: Args{
+				"source": `include <iostream>
+
+				int main() {
+					std::cout << "Hello world!" << std::endl;
+				}`,
+				"cflags": "/NOPE",
+			},
+			ShouldError: true,
+		},
+	}
+
+	runCheckerTests(t, tests, availableChecks["compile-visual-studio"])
+}

--- a/checks/script.go
+++ b/checks/script.go
@@ -1,7 +1,6 @@
 // Copyright 2018 Mathew Robinson <chasinglogic@gmail.com>. All rights reserved. Use of this source code is
 // governed by the Apache-2.0 license that can be found in the LICENSE file.
 
-
 package checks
 
 import (
@@ -89,15 +88,26 @@ func (rs RunScript) Check() error {
 		return fmt.Errorf("Problem running the script: %s: %s", err.Error(), string(out))
 	}
 
-	if rs.Output != "" && strings.TrimRight(string(out), "\n") != rs.Output {
+	if rs.Output == "" {
+		return nil
+	}
+
+	var trimmed string
+	if runtime.GOOS == "windows" {
+		trimmed = strings.TrimRight(string(out), "\r\n")
+	} else {
+		trimmed = strings.TrimRight(string(out), "\n")
+	}
+
+	if trimmed != rs.Output {
 		return fmt.Errorf("Output doesn't match. Expected '%s'\nActual output: %s", rs.Output, string(out))
 	}
 
 	return nil
 }
 
-// FromArgs will populate the RunScript with the args given in the tests YAML
-// config
+// RunScriptFromArgs will populate the RunScript with the args given in the
+// tests YAML config
 func RunScriptFromArgs(args Args) (Checker, error) {
 	rs := RunScript{}
 
@@ -110,7 +120,7 @@ func RunScriptFromArgs(args Args) (Checker, error) {
 	}
 
 	if _, interpreterGiven := args["interpreter"]; rs.Interpreter == "" && !interpreterGiven {
-		rs.Interpreter = "/bin/bash"
+		rs.Interpreter = "bash"
 	}
 
 	if _, outputGiven := args["output"]; rs.Output == "" && !outputGiven {


### PR DESCRIPTION
```
ministrator@WIN-CUH0BN4DPR0 /cygdrive/z/data/go/src/github.com/chasinglogic/redalert
$ rm -rf /tmp/compileVisualStudio_* && go test -v ./checks/
=== RUN   TestCompileGcc
--- PASS: TestCompileGcc (0.00s)
=== RUN   TestRealVersionNumber
--- PASS: TestRealVersionNumber (0.00s)
=== RUN   TestCompileVisualStudio
=== RUN   TestCompileVisualStudio/visual-studio_compile_hello_world
=== RUN   TestCompileVisualStudio/visual-studio_compile_bad_hello_world
=== RUN   TestCompileVisualStudio/visual-studio_compile_hello_world_with_args
=== RUN   TestCompileVisualStudio/visual-studio_compile_hello_world_with_bad_args
--- PASS: TestCompileVisualStudio (2.74s)
    --- PASS: TestCompileVisualStudio/visual-studio_compile_hello_world (0.83s)
    --- PASS: TestCompileVisualStudio/visual-studio_compile_bad_hello_world (0.51s)
    	checks_test.go:39: visual-studio compile bad hello world: Error running checker: Problem running the Visual Studio compile: exit status 2:
    		Z:\data\go\src\github.com\chasinglogic\redalert\checks>call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\vcvars32.bat"

    		Z:\data\go\src\github.com\chasinglogic\redalert\checks>if 0 NEQ 0 exit /b 0

    		Z:\data\go\src\github.com\chasinglogic\redalert\checks>call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\cl.exe" /FoC:\cygwin\tmp\compileVisualStudio_091739502\out.exe C:\cygwin\tmp\compileVisualStudio_091739502\src.cpp
    		Microsoft (R) C/C++ Optimizing Compiler Version 19.00.24223 for x86
    		Copyright (C) Microsoft Corporation.  All rights reserved.

    		src.cpp
    		C:\cygwin\tmp\compileVisualStudio_091739502\src.cpp(1): error C2143: syntax error: missing ';' before '<'
    		C:\cygwin\tmp\compileVisualStudio_091739502\src.cpp(1): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
    		C:\cygwin\tmp\compileVisualStudio_091739502\src.cpp(3): error C2143: syntax error: missing ';' before '{'
    		C:\cygwin\tmp\compileVisualStudio_091739502\src.cpp(3): error C2447: '{': missing function header (old-style formal list?)

    		Z:\data\go\src\github.com\chasinglogic\redalert\checks>if 2 NEQ 0 exit /b 2
    --- PASS: TestCompileVisualStudio/visual-studio_compile_hello_world_with_args (0.88s)
    --- PASS: TestCompileVisualStudio/visual-studio_compile_hello_world_with_bad_args (0.51s)
    	checks_test.go:39: visual-studio compile hello world with bad args: Error running checker: Problem running the Visual Studio compile: exit status 2:
    		Z:\data\go\src\github.com\chasinglogic\redalert\checks>call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\vcvars32.bat"

    		Z:\data\go\src\github.com\chasinglogic\redalert\checks>if 0 NEQ 0 exit /b 0

    		Z:\data\go\src\github.com\chasinglogic\redalert\checks>call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\cl.exe" /FoC:\cygwin\tmp\compileVisualStudio_952196304\out.exe /NOPE C:\cygwin\tmp\compileVisualStudio_952196304\src.cpp
    		Microsoft (R) C/C++ Optimizing Compiler Version 19.00.24223 for x86
    		Copyright (C) Microsoft Corporation.  All rights reserved.

    		cl : Command line warning D9002 : ignoring unknown option '/NOPE'
    		src.cpp
    		C:\cygwin\tmp\compileVisualStudio_952196304\src.cpp(1): error C2143: syntax error: missing ';' before '<'
    		C:\cygwin\tmp\compileVisualStudio_952196304\src.cpp(1): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
    		C:\cygwin\tmp\compileVisualStudio_952196304\src.cpp(3): error C2143: syntax error: missing ';' before '{'
    		C:\cygwin\tmp\compileVisualStudio_952196304\src.cpp(3): error C2447: '{': missing function header (old-style formal list?)

    		Z:\data\go\src\github.com\chasinglogic\redalert\checks>if 2 NEQ 0 exit /b 2
=== RUN   TestFileExists
--- PASS: TestFileExists (0.00s)
=== RUN   TestFileNotExists
--- PASS: TestFileNotExists (0.00s)
=== RUN   TestGemInstalled
--- PASS: TestGemInstalled (0.01s)
=== RUN   TestPythonModuleVersion
=== RUN   TestPythonModuleVersion/pyyaml_should_be_installed
=== RUN   TestPythonModuleVersion/pyyaml_should_be_at_least_version_3.00
=== RUN   TestPythonModuleVersion/pyyaml_should_be_version_3.13
=== RUN   TestPythonModuleVersion/pyyaml_should_not_be_version_4.00
=== RUN   TestPythonModuleVersion/NOT_A_PYTHON_MODULE_should_be_installed
--- FAIL: TestPythonModuleVersion (0.23s)
    --- PASS: TestPythonModuleVersion/pyyaml_should_be_installed (0.05s)
    --- PASS: TestPythonModuleVersion/pyyaml_should_be_at_least_version_3.00 (0.05s)
    --- FAIL: TestPythonModuleVersion/pyyaml_should_be_version_3.13 (0.05s)
    	checks_test.go:41: pyyaml should be version 3.13: Check error: 3.11.0 is not equal to 3.13.0
    --- PASS: TestPythonModuleVersion/pyyaml_should_not_be_version_4.00 (0.05s)
    	checks_test.go:39: pyyaml should not be version 4.00: Error running checker: 3.11.0 is not greater than or equal to 4.0.0
    --- PASS: TestPythonModuleVersion/NOT_A_PYTHON_MODULE_should_be_installed (0.03s)
    	checks_test.go:39: NOT_A_PYTHON_MODULE should be installed: Error running checker: NOT_A_PYTHON_MODULE isn't installed and should be: exit status 1, Traceback (most recent call last):
    		  File "<string>", line 1, in <module>
    		ImportError: No module named NOT_A_PYTHON_MODULE
=== RUN   TestRegistryKeyChecker
=== RUN   TestRegistryKeyChecker/check_dword_value
=== RUN   TestRegistryKeyChecker/check_path_exists
=== RUN   TestRegistryKeyChecker/check_path_doesn't_exist
--- PASS: TestRegistryKeyChecker (0.00s)
    --- PASS: TestRegistryKeyChecker/check_dword_value (0.00s)
    --- PASS: TestRegistryKeyChecker/check_path_exists (0.00s)
    --- PASS: TestRegistryKeyChecker/check_path_doesn't_exist (0.00s)
    	checks_test.go:39: check path doesn't exist: Error running checker: unable to open path: SOFTWARE\Microsoft\Windows NT\NotARealPath: The system cannot find the file specified.
=== RUN   TestRunUnixShellScript
=== RUN   TestRunUnixShellScript/exit_0_check_for_exit_code
=== RUN   TestRunUnixShellScript/exit_1_check_for_exit_code
=== RUN   TestRunUnixShellScript/run_bad_command
=== RUN   TestRunUnixShellScript/echo_123_checks_for_123
=== RUN   TestRunUnixShellScript/echo_123_checks_for_111
=== RUN   TestRunUnixShellScript/echo_123_with_good_interpreter
=== RUN   TestRunUnixShellScript/echo_123_with_bad_interpreter
--- FAIL: TestRunUnixShellScript (0.10s)
    --- PASS: TestRunUnixShellScript/exit_0_check_for_exit_code (0.02s)
    --- PASS: TestRunUnixShellScript/exit_1_check_for_exit_code (0.02s)
    	checks_test.go:39: exit 1 check for exit code: Error running checker: Problem running the script: exit status 1:
    --- PASS: TestRunUnixShellScript/run_bad_command (0.03s)
    	checks_test.go:39: run bad command: Error running checker: Problem running the script: exit status 2: ls: cannot access '/fake_dir': No such file or directory
    --- PASS: TestRunUnixShellScript/echo_123_checks_for_123 (0.02s)
    --- PASS: TestRunUnixShellScript/echo_123_checks_for_111 (0.02s)
    	checks_test.go:39: echo 123 checks for 111: Error running checker: Output doesn't match. Expected '111'
    		Actual output: 123
    --- FAIL: TestRunUnixShellScript/echo_123_with_good_interpreter (0.00s)
    	checks_test.go:41: echo 123 with good interpreter: Check error: Problem running the script: exec: "/bin/sh": file does not exist:
    --- PASS: TestRunUnixShellScript/echo_123_with_bad_interpreter (0.00s)
    	checks_test.go:39: echo 123 with bad interpreter: Error running checker: Problem running the script: exec: "/bin/shhh": file does not exist:
=== RUN   TestRunPythonScript
=== RUN   TestRunPythonScript/python_print_123_expecting_123
=== RUN   TestRunPythonScript/python_print_123_expecting_111
=== RUN   TestRunPythonScript/python_exit_0_check_for_exit_code
=== RUN   TestRunPythonScript/python_exit_1_check_for_exit_code
=== RUN   TestRunPythonScript/python_import_module_check_exit_code
=== RUN   TestRunPythonScript/python_import_bad_module_check_exit_code
--- PASS: TestRunPythonScript (0.16s)
    --- PASS: TestRunPythonScript/python_print_123_expecting_123 (0.03s)
    --- PASS: TestRunPythonScript/python_print_123_expecting_111 (0.03s)
    	checks_test.go:39: python print 123 expecting 111: Error running checker: Output doesn't match. Expected '111'
    		Actual output: 123
    --- PASS: TestRunPythonScript/python_exit_0_check_for_exit_code (0.03s)
    --- PASS: TestRunPythonScript/python_exit_1_check_for_exit_code (0.03s)
    	checks_test.go:39: python exit 1 check for exit code: Error running checker: Problem running the script: exit status 1:
    --- PASS: TestRunPythonScript/python_import_module_check_exit_code (0.03s)
    --- PASS: TestRunPythonScript/python_import_bad_module_check_exit_code (0.03s)
    	checks_test.go:39: python import bad module check exit code: Error running checker: Problem running the script: exit status 1: Traceback (most recent call last):
    		  File "C:\cygwin\tmp\testScript_340560027", line 1, in <module>
    		    import datetimes
    		ImportError: No module named datetimes
FAIL
exit status 1
FAIL	github.com/chasinglogic/redalert/checks	3.269s
```

Test output from a Windows host